### PR TITLE
Fixed the upload test to fail if the response was not correct. 

### DIFF
--- a/src/test/scala/com/rishi/FileUploadSpec.scala
+++ b/src/test/scala/com/rishi/FileUploadSpec.scala
@@ -29,7 +29,7 @@ class FileUploadSpec extends FlatSpec with Matchers with ScalatestRouteTest with
     val formData = Multipart.FormData.fromFile("file", ContentTypes.`application/octet-stream`, file, 100000)
     Post(s"/user/upload/file", formData) ~> routes ~> check {
       status shouldBe StatusCodes.OK
-      responseAs[String] contains "File successfully uploaded"
+      responseAs[String] should include("File successfully uploaded")
     }
   }
 }


### PR DESCRIPTION
Original 'contains' just returned a Boolean on whether it contained the value or not, but didn't fail the test if it was not present